### PR TITLE
unicode strings → strings

### DIFF
--- a/itemloaders/__init__.py
+++ b/itemloaders/__init__.py
@@ -328,7 +328,7 @@ class ItemLoader:
     def add_xpath(self, field_name, xpath, *processors, **kw):
         """
         Similar to :meth:`ItemLoader.add_value` but receives an XPath instead of a
-        value, which is used to extract a list of unicode strings from the
+        value, which is used to extract a list of strings from the
         selector associated with this :class:`ItemLoader`.
 
         See :meth:`get_xpath` for ``kwargs``.


### PR DESCRIPTION
I believe “unicode strings” comes from Python 2 times.

Related to https://github.com/scrapy/scrapy/pull/4661