### PR TITLE
Fix references to Python types in parameter type fields

### DIFF
--- a/itemloaders/__init__.py
+++ b/itemloaders/__init__.py
@@ -223,7 +223,7 @@ class ItemLoader:
         :param re: a regular expression to use for extracting data from the
             given value using :meth:`~parsel.utils.extract_regex` method,
             applied before processors
-        :type re: str or compiled regex
+        :type re: str or typing.Pattern
 
         Examples:
 
@@ -365,7 +365,7 @@ class ItemLoader:
 
         :param re: a regular expression to use for extracting data from the
             selected XPath region
-        :type re: str or compiled regex
+        :type re: str or typing.Pattern
 
         Examples::
 
@@ -422,7 +422,7 @@ class ItemLoader:
 
         :param re: a regular expression to use for extracting data from the
             selected CSS region
-        :type re: str or compiled regex
+        :type re: str or typing.Pattern
 
         Examples::
 


### PR DESCRIPTION
Ported from https://github.com/scrapy/scrapy/pull/4090