### PR TITLE
Fix documentation references

### DIFF
--- a/docs/built-in-processors.rst
+++ b/docs/built-in-processors.rst
@@ -4,10 +4,12 @@ Available built-in processors
 =============================
 
 Even though you can use any callable function as input and output processors,
-``itemloaders`` provides some commonly used processors, which are described below. Some
-of them, like the :class:`MapCompose` (which is typically used as input
-processor) compose the output of several functions executed in order, to
-produce the final parsed value.
+``itemloaders`` provides some commonly used processors, which are described
+below.
+
+Some of them, like the :class:`~itemloaders.processors.MapCompose` (which is
+typically used as input processor) compose the output of several functions
+executed in order, to produce the final parsed value.
 
 Here is a list of all built-in processors:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@ sys.path.insert(0, path.dirname(path.dirname(__file__)))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
+    'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
 ]
 
@@ -218,3 +219,11 @@ def maybe_skip_member(app, what, name, obj, skip, options):
         # https://github.com/sphinx-doc/sphinx/issues/4422
         return name in {'default_item_class', 'default_selector_class'}
     return skip
+
+
+nitpicky = True
+
+intersphinx_mapping = {
+    'parsel': ('https://parsel.readthedocs.io/en/stable/', None),
+    'python': ('https://docs.python.org/3', None),
+}

--- a/docs/declaring-loaders.rst
+++ b/docs/declaring-loaders.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: itemloaders
+
 .. _declaring-loaders:
 
 Declaring Item Loaders

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: itemloaders
+
 .. _topics-index:
 
 ============

--- a/docs/loaders-context.rst
+++ b/docs/loaders-context.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: itemloaders
+
 .. _loaders-context:
 
 Item Loader Context
@@ -36,7 +38,7 @@ There are several ways to modify Item Loader context values:
       loader = ItemLoader(product, unit='cm')
 
 3. On Item Loader declaration, for those input/output processors that support
-   instantiating them with an Item Loader context. :class:`~processor.MapCompose` is one of
+   instantiating them with an Item Loader context. :class:`~processors.MapCompose` is one of
    them::
 
        class ProductLoader(ItemLoader):

--- a/docs/processors.rst
+++ b/docs/processors.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: itemloaders
+
 .. _processors:
 
 Input and Output processors

--- a/itemloaders/__init__.py
+++ b/itemloaders/__init__.py
@@ -42,7 +42,7 @@ class ItemLoader:
     :param selector: The selector to extract data from, when using the
         :meth:`add_xpath` (resp. :meth:`add_css`) or :meth:`replace_xpath`
         (resp. :meth:`replace_css`) method.
-    :type selector: :class:`~parsel.Selector` object
+    :type selector: :class:`~parsel.selector.Selector` object
 
     The item, selector and the remaining keyword arguments are
     assigned to the Loader context (accessible through the :attr:`context` attribute).
@@ -88,7 +88,7 @@ class ItemLoader:
 
     .. attribute:: selector
 
-        The :class:`~parsel.Selector` object to extract data from.
+        The :class:`~parsel.selector.Selector` object to extract data from.
         It's the selector given in the ``__init__`` method.
         This attribute is meant to be read-only.
 
@@ -222,7 +222,7 @@ class ItemLoader:
         Available keyword arguments:
 
         :param re: a regular expression to use for extracting data from the
-            given value using :meth:`~parsel.utils.extract_regex` method,
+            given value using :func:`~parsel.utils.extract_regex` method,
             applied before processors
         :type re: str or typing.Pattern
 

--- a/itemloaders/processors.py
+++ b/itemloaders/processors.py
@@ -33,7 +33,7 @@ class MapCompose:
     work with single values (instead of iterables). For this reason the
     :class:`MapCompose` processor is typically used as input processor, since
     data is often extracted using the
-    :meth:`~parsel.Selector.extract` method of `parsel selectors`_,
+    :meth:`~parsel.selector.Selector.extract` method of `parsel selectors`_,
     which returns a list of unicode strings.
 
     The example below should clarify how it works:
@@ -103,8 +103,8 @@ class Compose:
     The keyword arguments passed in the ``__init__`` method are used as the default
     Loader context values passed to each function call. However, the final
     Loader context values passed to functions are overridden with the currently
-    active Loader context accessible through the :meth:`ItemLoader.context`
-    attribute.
+    active Loader context accessible through the :attr:`ItemLoader.context
+    <itemloaders.ItemLoader.context>` attribute.
     """
 
     def __init__(self, *functions, **default_loader_context):


### PR DESCRIPTION
Fixes documentation references through the use of the `currentmodule` Sphinx directive and the `InterSphinx` extension.

Also enables the `nitpick` Sphinx option, so that any broken references added in the future cause the documentation job to fail.