### PR TITLE
add the default parameter to get_output_value

### DIFF
--- a/itemloaders/__init__.py
+++ b/itemloaders/__init__.py
@@ -266,7 +266,7 @@ class ItemLoader:
 
         return adapter.item
 
-    def get_output_value(self, field_name):
+    def get_output_value(self, field_name, default=None):
         """
         Return the collected values parsed using the output processor, for the
         given field. This method doesn't populate or modify the item at all.
@@ -275,10 +275,13 @@ class ItemLoader:
         proc = wrap_loader_context(proc, self.context)
         value = self._values.get(field_name, [])
         try:
-            return proc(value)
+            result = proc(value)
         except Exception as e:
             raise ValueError("Error with output processor: field=%r value=%r error='%s: %s'" %
                              (field_name, value, type(e).__name__, str(e)))
+        if not result and default is not None:
+            return default
+        return result
 
     def get_collected_values(self, field_name):
         """Return the collected values for the given field."""

--- a/tests/test_base_loader.py
+++ b/tests/test_base_loader.py
@@ -68,7 +68,7 @@ class BasicItemLoaderTest(unittest.TestCase):
             url_out = TakeFirst()
 
             def img_url_out(self, values):
-                return (self.get_output_value('url') or '') + values[0]
+                return self.get_output_value('url', '') + values[0]
 
         il = MyLoader(item={})
         il.add_value('url', 'http://example.com/')

--- a/tests/test_loader_initialization.py
+++ b/tests/test_loader_initialization.py
@@ -1,6 +1,7 @@
 import unittest
 
 from itemloaders import ItemLoader
+from itemloaders.processors import TakeFirst
 
 
 class InitializationTestMixin:
@@ -76,6 +77,54 @@ class InitializationTestMixin:
         loaded_item = il.load_item()
         self.assertIsInstance(loaded_item, self.item_class)
         self.assertEqual(loaded_item, dict({'name': ['foo', 'bar']}))
+
+    def test_get_output_value_default_singlevalue(self):
+        """
+        The default value should be used only when the returned value is
+        empty (None, '', etc.) and there is a default value defined
+        """
+        input_item = self.item_class()
+        il = ItemLoader(item=input_item)
+        il.default_output_processor = TakeFirst()  # make "name" field single
+
+        self.assertEqual(il.get_output_value('name'), None)
+        self.assertEqual(il.get_output_value('name', ''), '')
+        self.assertEqual(il.get_output_value('name', []), [])
+        self.assertEqual(il.get_output_value('name', 'foo'), 'foo')
+
+        il.add_value('name', '')
+        self.assertEqual(il.get_output_value('name'), None)
+        self.assertEqual(il.get_output_value('name', ''), '')
+        self.assertEqual(il.get_output_value('name', []), [])
+        self.assertEqual(il.get_output_value('name', 'foo'), 'foo')
+        self.assertEqual(il.load_item(), {})
+
+        input_item2 = self.item_class()
+        il2 = ItemLoader(item=input_item2)
+        il2.default_output_processor = TakeFirst()
+        il2.add_value('name', 'foo')
+        self.assertEqual(il2.get_output_value('name'), 'foo')
+        self.assertEqual(il2.get_output_value('name', 'bar'), 'foo')
+        self.assertEqual(il2.load_item(), dict({'name': 'foo'}))
+
+    def test_get_output_value_default_list(self):
+        """
+        The default value should be used only when the returned value is
+        empty ([], etc.) and there is a default value defined
+        """
+        input_item = self.item_class()
+        il = ItemLoader(item=input_item)
+        il.add_value('name', [])
+        self.assertEqual(il.get_output_value('name'), [])
+        self.assertEqual(il.get_output_value('name', 'foo'), 'foo')
+        self.assertEqual(il.load_item(), {})
+
+        input_item2 = self.item_class()
+        il2 = ItemLoader(item=input_item2)
+        il2.add_value('name', ['foo', 'bar'])
+        self.assertEqual(il2.get_output_value('name'), ['foo', 'bar'])
+        self.assertEqual(il2.get_output_value('name', ['spam']), ['foo', 'bar'])
+        self.assertEqual(il2.load_item(), dict({'name': ['foo', 'bar']}))
 
     def test_values_single(self):
         """Values from initial item must be added to loader._values"""

--- a/tests/test_loader_initialization.py
+++ b/tests/test_loader_initialization.py
@@ -116,6 +116,7 @@ class InitializationTestMixin:
         il = ItemLoader(item=input_item)
         il.add_value('name', [])
         self.assertEqual(il.get_output_value('name'), [])
+        self.assertEqual(il.get_output_value('name', ['foo']), ['foo'])
         self.assertEqual(il.get_output_value('name', 'foo'), 'foo')
         self.assertEqual(il.load_item(), {})
 


### PR DESCRIPTION
Hey guys! Good job decoupling this from Scrapy!

I’ve been thinking about the possibility of adding a default value for the `get_output_value()`.

So as an example, you could do:

```python
item_loader.get_output_value('name', 'Foobar')
```

and you would receive the value for `name` if it's available or `'Foobar'` if it's not available.


The implementation seems quite simple, but there are a lot of scenarios that I tried to reproduce in the tests.

Could you?

**1. Let me know if you like the idea.** 
I decided to implement it because I frequently find something similar to:

```python
item_loader.get_output_value('name') or ''
```

**2. Check the tests I added and see if it's what you expect or not.**
If you see any missed case you can also let me know it.


Thanks in advance!