### PR TITLE
increase coverage

### DIFF
--- a/tests/test_base_loader.py
+++ b/tests/test_base_loader.py
@@ -104,6 +104,11 @@ class BasicItemLoaderTest(unittest.TestCase):
         il.add_value('name', 0)
         assert il.get_collected_values('name') == [0]
 
+    def test_add_none(self):
+        il = ItemLoader()
+        il.add_value('name', None)
+        assert il.get_collected_values('name') == []
+
     def test_replace_value(self):
         il = CustomItemLoader()
         il.replace_value('name', 'marta')
@@ -116,11 +121,22 @@ class BasicItemLoaderTest(unittest.TestCase):
         il.replace_value(None, 'Jim', lambda x: {'name': x})
         self.assertEqual(il.get_collected_values('name'), ['Jim'])
 
+    def test_replace_value_none(self):
+        il = CustomItemLoader()
+        il.replace_value('name', None)
+        self.assertEqual(il.get_collected_values('name'), [])
+        il.replace_value('name', 'marta')
+        self.assertEqual(il.get_collected_values('name'), ['Marta'])
+        il.replace_value('name', None)  # when replacing with `None` nothing should happen
+        self.assertEqual(il.get_collected_values('name'), ['Marta'])
+
     def test_get_value(self):
         il = ItemLoader()
         self.assertEqual('FOO', il.get_value(['foo', 'bar'], TakeFirst(), str.upper))
         self.assertEqual(['foo', 'bar'], il.get_value(['name:foo', 'name:bar'], re='name:(.*)$'))
         self.assertEqual('foo', il.get_value(['name:foo', 'name:bar'], TakeFirst(), re='name:(.*)$'))
+        self.assertEqual(None, il.get_value(['foo', 'bar'], TakeFirst(), re='name:(.*)$'))
+        self.assertEqual(None, il.get_value(None, TakeFirst()))
 
         il.add_value('name', ['name:foo', 'name:bar'], TakeFirst(), re='name:(.*)$')
         self.assertEqual(['foo'], il.get_collected_values('name'))

--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -42,6 +42,8 @@ class UtilsPythonTestCase(unittest.TestCase):
         self.assertEqual(get_func_args(partial_f3), ['c'])
         self.assertEqual(get_func_args(cal), ['a', 'b', 'c'])
         self.assertEqual(get_func_args(object), [])
+        with self.assertRaises(TypeError):
+            get_func_args(None)
 
         if platform.python_implementation() == 'CPython':
             # TODO: how do we fix this to return the actual argument names?


### PR DESCRIPTION
I added some tests to increase the coverage.

After fixing this, there is only one missing line in the `unbound_method` to have a 100% of coverage. That function is not tested directly (the same happens with the functions that use it: `get_input_processor` and `get_output_processor`).

I personally think that this `unbound_method` should be:
1. Moved to private scope by adding `_` (i.e.: `_unbound_method`) or
2. Moved to utils

In both cases, we should probably add some unit tests for it. What do you think?