### PR TITLE
Restore support for nested Scrapy items

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,19 @@ matrix:
   - python: 3.7
     env: TOXENV=docs
 
-  - python: 3.5
-    env: TOXENV=py35
   - python: 3.6
-    env: TOXENV=py36
+    env: TOXENV=py
   - python: 3.7
-    env: TOXENV=py37
+    env: TOXENV=py
   - python: 3.8
-    env: TOXENV=py38
+    env: TOXENV=py
+  - python: 3.9
+    env: TOXENV=py
 
   - python: pypy3
     env: TOXENV=pypy3
 
-  - python: 3.8
+  - python: 3.9
     env: TOXENV=extra-deps
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,11 @@ matrix:
     env: TOXENV=py
   - python: 3.8
     env: TOXENV=py
-  - python: 3.9
-    env: TOXENV=py
 
   - python: pypy3
     env: TOXENV=pypy3
 
-  - python: 3.9
+  - python: 3.8
     env: TOXENV=extra-deps
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ branches:
 
 matrix:
   include:
+  - python: 3.7
+    env: TOXENV=docs
+
   - python: 3.5
     env: TOXENV=py35
   - python: 3.6
@@ -19,8 +22,8 @@ matrix:
   - python: pypy3
     env: TOXENV=pypy3
 
-  - python: 3.7
-    env: TOXENV=docs
+  - python: 3.8
+    env: TOXENV=extra-deps
 
 install:
 - pip install -U tox codecov

--- a/itemloaders/utils.py
+++ b/itemloaders/utils.py
@@ -2,11 +2,13 @@
 Copy/paste from scrapy source at the moment, to ensure tests are working.
 Refactoring to come later
 """
-from functools import partial
 import inspect
+from functools import partial
+
+from itemadapter import is_item
 
 
-_ITERABLE_SINGLE_VALUES = dict, str, bytes
+_ITERABLE_SINGLE_VALUES = str, bytes
 
 
 def arg_to_iter(arg):
@@ -17,7 +19,11 @@ def arg_to_iter(arg):
     """
     if arg is None:
         return []
-    elif not isinstance(arg, _ITERABLE_SINGLE_VALUES) and hasattr(arg, '__iter__'):
+    elif (
+        hasattr(arg, '__iter__')
+        and not isinstance(arg, _ITERABLE_SINGLE_VALUES)
+        and not is_item(arg)
+    ):
         return arg
     else:
         return [arg]

--- a/setup.py
+++ b/setup.py
@@ -27,14 +27,14 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     install_requires=[
         # before updating these versions, be sure they are not higher than
         # scrapy's requirements

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/tests/test_nested_items.py
+++ b/tests/test_nested_items.py
@@ -1,5 +1,4 @@
 import unittest
-from dataclasses import dataclass
 
 from itemloaders import ItemLoader
 
@@ -23,6 +22,11 @@ class NestedItemTest(unittest.TestCase):
         self.assertEqual(il.load_item(), {'item_list': [item]})
 
     def test_dataclass(self):
+        try:
+            from dataclasses import dataclass
+        except ImportError:
+            self.skipTest("Cannot import dataclasses.dataclass")
+
         @dataclass
         class TestItem:
             foo: str

--- a/tests/test_nested_items.py
+++ b/tests/test_nested_items.py
@@ -6,6 +6,11 @@ from itemloaders import ItemLoader
 class NestedItemTest(unittest.TestCase):
     """Test that adding items as values works as expected."""
 
+    def _test_item(self, item):
+        il = ItemLoader()
+        il.add_value('item_list', item)
+        self.assertEqual(il.load_item(), {'item_list': [item]})
+
     def test_attrs(self):
         try:
             import attr
@@ -16,10 +21,7 @@ class NestedItemTest(unittest.TestCase):
         class TestItem:
             foo = attr.ib()
 
-        item = TestItem(foo='bar')
-        il = ItemLoader()
-        il.add_value('item_list', item)
-        self.assertEqual(il.load_item(), {'item_list': [item]})
+        self._test_item(TestItem(foo='bar'))
 
     def test_dataclass(self):
         try:
@@ -31,16 +33,10 @@ class NestedItemTest(unittest.TestCase):
         class TestItem:
             foo: str
 
-        item = TestItem(foo='bar')
-        il = ItemLoader()
-        il.add_value('item_list', item)
-        self.assertEqual(il.load_item(), {'item_list': [item]})
+        self._test_item(TestItem(foo='bar'))
 
     def test_dict(self):
-        item = {'foo': 'bar'}
-        il = ItemLoader()
-        il.add_value('item_list', item)
-        self.assertEqual(il.load_item(), {'item_list': [item]})
+        self._test_item({'foo': 'bar'})
 
     def test_scrapy_item(self):
         try:
@@ -51,7 +47,4 @@ class NestedItemTest(unittest.TestCase):
         class TestItem(Item):
             foo = Field()
 
-        item = TestItem(foo='bar')
-        il = ItemLoader()
-        il.add_value('item_list', item)
-        self.assertEqual(il.load_item(), {'item_list': [item]})
+        self._test_item(TestItem(foo='bar'))

--- a/tests/test_nested_items.py
+++ b/tests/test_nested_items.py
@@ -1,13 +1,7 @@
 import unittest
 from dataclasses import dataclass
 
-from itemloaders import ItemLoader as BaseItemLoader
-from itemloaders.processors import Identity
-
-
-class ItemLoader(BaseItemLoader):
-    item_list_in = Identity()
-    item_list_out = Identity()
+from itemloaders import ItemLoader
 
 
 class NestedItemTest(unittest.TestCase):

--- a/tests/test_nested_items.py
+++ b/tests/test_nested_items.py
@@ -1,0 +1,59 @@
+import unittest
+from dataclasses import dataclass
+
+from itemloaders import ItemLoader as BaseItemLoader
+from itemloaders.processors import Identity
+
+
+class ItemLoader(BaseItemLoader):
+    item_list_in = Identity()
+    item_list_out = Identity()
+
+
+class NestedItemTest(unittest.TestCase):
+    """Test that adding items as values works as expected."""
+
+    def test_attrs(self):
+        try:
+            import attr
+        except ImportError:
+            self.skipTest("Cannot import attr")
+
+        @attr.s
+        class TestItem:
+            foo = attr.ib()
+
+        item = TestItem(foo='bar')
+        il = ItemLoader()
+        il.add_value('item_list', item)
+        self.assertEqual(il.load_item(), {'item_list': [item]})
+
+    def test_dataclass(self):
+        @dataclass
+        class TestItem:
+            foo: str
+
+        item = TestItem(foo='bar')
+        il = ItemLoader()
+        il.add_value('item_list', item)
+        self.assertEqual(il.load_item(), {'item_list': [item]})
+
+    def test_dict(self):
+        item = {'foo': 'bar'}
+        il = ItemLoader()
+        il.add_value('item_list', item)
+        self.assertEqual(il.load_item(), {'item_list': [item]})
+
+    def test_scrapy_item(self):
+        try:
+            from scrapy import Field, Item
+        except ImportError:
+            self.skipTest("Cannot import Field or Item from scrapy")
+
+        class TestItem(Item):
+            foo = Field()
+
+        item = TestItem(foo='bar')
+        il = ItemLoader()
+        il.add_value('item_list', item)
+        self.assertEqual(il.load_item(), {'item_list': [item]})

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,12 @@ commands =
         --doctest-modules \
         {posargs:itemloaders tests}
 
+[testenv:extra-deps]
+deps =
+    {[testenv]deps}
+    attrs
+    scrapy
+
 [testenv:pypy3]
 basepython = pypy3
 


### PR DESCRIPTION
Fixes #28

The attrs syntax is not supported in Python 3.5. Since Python 3.5 reached end-of-life, instead of making test code more complex to support 3.5, I went ahead and removed official support for 3.5 (it will actually still work, but not officially since we are not covering it in tests).

Originally I also added 3.9 official support, but it looks like 3.9 has not reached Travis yet.