### PR TITLE
add judgement to _add_value

### DIFF
--- a/itemloaders/__init__.py
+++ b/itemloaders/__init__.py
@@ -8,9 +8,9 @@ from contextlib import suppress
 from itemadapter import ItemAdapter
 from parsel.utils import extract_regex, flatten
 
-from itemloaders.common import wrap_loader_context
-from itemloaders.processors import Identity
-from itemloaders.utils import arg_to_iter
+from jay.itemloaders.common import wrap_loader_context
+from jay.itemloaders.processors import Identity
+from jay.itemloaders.utils import arg_to_iter
 
 
 def unbound_method(method):
@@ -208,7 +208,10 @@ class ItemLoader:
         processed_value = self._process_input_value(field_name, value)
         if processed_value:
             self._values.setdefault(field_name, [])
-            self._values[field_name] += arg_to_iter(processed_value)
+            if type(arg_to_iter(processed_value)) == list:
+                self._values[field_name] += arg_to_iter(processed_value)
+            else:
+                self._values[field_name].append(arg_to_iter(processed_value))
 
     def _replace_value(self, field_name, value):
         self._values.pop(field_name, None)

--- a/tests/test_base_loader.py
+++ b/tests/test_base_loader.py
@@ -84,6 +84,9 @@ class BasicItemLoaderTest(unittest.TestCase):
 
     def test_add_value(self):
         il = CustomItemLoader()
+        til = CustomItemLoader()
+        til.add_value('test_item','scx')
+
         il.add_value('name', 'marta')
         assert il.get_collected_values('name') == ['Marta']
         assert il.get_output_value('name') == ['Marta']
@@ -98,6 +101,9 @@ class BasicItemLoaderTest(unittest.TestCase):
 
         il.add_value(None, 'Jim', lambda x: {'name': x})
         assert il.get_collected_values('name') == ['Marta', 'Pepe', 'Jim']
+
+        il.add_value('item', til)
+        assert il.get_collected_values('item') == til
 
     def test_add_zero(self):
         il = ItemLoader()


### PR DESCRIPTION
hello!
I found that if add a scrapy item to itemloader, += will lose its value.
so I added the previous version of the method back, use append to add an item.