### PR TITLE
fixed add_xpath with variables

### DIFF
--- a/itemloaders/__init__.py
+++ b/itemloaders/__init__.py
@@ -383,7 +383,7 @@ class ItemLoader:
     def _get_xpathvalues(self, xpaths, **kw):
         self._check_selector_method()
         xpaths = arg_to_iter(xpaths)
-        return flatten(self.selector.xpath(xpath).getall() for xpath in xpaths)
+        return flatten(self.selector.xpath(xpath, **kw).getall() for xpath in xpaths)
 
     def add_css(self, field_name, css, *processors, **kw):
         """

--- a/tests/test_selector_loader.py
+++ b/tests/test_selector_loader.py
@@ -64,6 +64,14 @@ class SelectortemLoaderTest(unittest.TestCase):
         loader.add_xpath('name', '//div/text()', re='ma')
         self.assertEqual(loader.get_output_value('name'), ['Ma'])
 
+    def test_add_xpath_variables(self):
+        loader = CustomItemLoader(selector=self.selector)
+        loader.add_xpath('name', 'id($id)/text()', id="id")
+        self.assertEqual(loader.get_output_value('name'), ['Marta'])
+        loader = CustomItemLoader(selector=self.selector)
+        loader.add_xpath('name', 'id($id)/text()', id="id2")
+        self.assertEqual(loader.get_output_value('name'), [])
+
     def test_replace_xpath(self):
         loader = CustomItemLoader(selector=self.selector)
         self.assertTrue(loader.selector)


### PR DESCRIPTION
I got `XPath error: Undefined variable in id($id)/text()` for `loader.add_xpath("field", "id($id)/text()", id="myid")` and this PR fixes it.