### PR TITLE
Release 1.0.5

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -5,6 +5,19 @@
 Release notes
 =============
 
+.. _release-1.0.5:
+
+itemloaders 1.0.5 (2022-08-NN)
+------------------------------
+
+-  Allow additional args to be passed when calling :meth:`ItemLoader.add_xpath` (:gh:`48`)
+
+-  Fixed missing space in exception message (:gh: `47`)
+
+-  Updated company name in author and copyright sections (:gh: `42`)
+
+-  Added official support for python 3.9
+
 .. _release-1.0.4:
 
 itemloaders 1.0.4 (2020-11-12)

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -16,7 +16,9 @@ itemloaders 1.0.5 (2022-08-NN)
 
 -  Updated company name in author and copyright sections (:gh: `42`)
 
--  Added support for python 3.9 and python 3.10 (:gh: `53`)
+-  Added official support for python 3.9 and improve PyPy compatibility (:gh: `44`)
+
+-  Added official support for python 3.10 (:gh: `53`)
 
 .. _release-1.0.4:
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -16,7 +16,7 @@ itemloaders 1.0.5 (2022-08-NN)
 
 -  Updated company name in author and copyright sections (:gh: `42`)
 
--  Added official support for python 3.9
+-  Added official support for python 3.9 and python 3.10 (:gh: `53`)
 
 .. _release-1.0.4:
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -12,13 +12,13 @@ itemloaders 1.0.5 (2022-08-NN)
 
 -  Allow additional args to be passed when calling :meth:`ItemLoader.add_xpath` (:gh:`48`)
 
--  Fixed missing space in exception message (:gh: `47`)
+-  Fixed missing space in an exception message (:gh:`47`)
 
--  Updated company name in author and copyright sections (:gh: `42`)
+-  Updated company name in author and copyright sections (:gh:`42`)
 
--  Added official support for python 3.9 and improve PyPy compatibility (:gh: `44`)
+-  Added official support for Python 3.9 and improved PyPy compatibility (:gh:`44`)
 
--  Added official support for python 3.10 (:gh: `53`)
+-  Added official support for Python 3.10 (:gh:`53`)
 
 .. _release-1.0.4:
 


### PR DESCRIPTION
-  Allow additional args to be passed when calling :meth:`ItemLoader.add_xpath` (:gh:`48`)

-  Fixed missing space in exception message (:gh: `47`)

-  Updated company name in author and copyright sections (:gh: `42`)

-  Added support for python 3.9 and python 3.10 (:gh: `53`)
