### PR TITLE
Disable codecov project check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "header, diff, tree"
+
+coverage:
+  status:
+    project: false


### PR DESCRIPTION
It should fix useless failures like we've got in https://github.com/scrapy/itemloaders/pull/59.