### PR TITLE
Add support for set type

### DIFF
--- a/itemloaders/utils.py
+++ b/itemloaders/utils.py
@@ -13,6 +13,8 @@ def arg_to_iter(arg: Any) -> Iterable[Any]:
 
     If *arg* is a list, a tuple or a generator, it will be returned as is.
 
+    If *arg* is a set, it will be casted to a list.
+
     If *arg* is ``None``, an empty list will be returned.
 
     If *arg* is anything else, a list will be returned with *arg* as its only
@@ -22,6 +24,8 @@ def arg_to_iter(arg: Any) -> Iterable[Any]:
         return []
     if isinstance(arg, (list, tuple, Generator)):
         return arg
+    if isinstance(arg, set):
+        return list(arg)
     return [arg]
 
 

--- a/tests/test_nested_items.py
+++ b/tests/test_nested_items.py
@@ -39,6 +39,13 @@ class NestedItemTest(unittest.TestCase):
     def test_dict(self):
         self._test_item({"foo": "bar"})
 
+    def test_set(self):
+        item = {"foo", "bar"}
+        il = ItemLoader()
+        il.add_value("item_list", item)
+
+        self.assertEqual(il.load_item(), {"item_list": list(item)})
+
     def test_scrapy_item(self):
         try:
             from scrapy import Field, Item


### PR DESCRIPTION
In the previous version (1.1.0), adding a set would return a list:
```py
$ pip freeze | grep itemloaders
itemloaders==1.1.0

$ cat test_set.py 
from itemloaders import ItemLoader

test_set = {"foo", "bar"}

il = ItemLoader()
il.add_value("item_list", test_set)

print(il.load_item())

$ python ./test_set.py 
{'item_list': ['bar', 'foo']}
```

In version 1.2.0, a list o af set would be returned:
```py
$ pip freeze | grep itemloaders
itemloaders==1.2.0

$ python ./test_set.py 
{'item_list': [{'bar', 'foo'}]}
```

This PR is aimed to keep the previous behaviour. Follow-up from https://github.com/scrapy/itemloaders/pull/51#issuecomment-2107173388