### PR TITLE
Drop the explicit dep on w3lib.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -230,5 +230,4 @@ intersphinx_mapping = {
     "parsel": ("https://parsel.readthedocs.io/en/stable/", None),
     "python": ("https://docs.python.org/3", None),
     "scrapy": ("https://docs.scrapy.org/en/latest/", None),
-    "w3lib": ("https://w3lib.readthedocs.io/en/latest", None),
 }

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -135,9 +135,9 @@ itemloaders 1.0.1 (2020-07-02)
 
 -   Lowered some minimum dependency versions (:gh:`10`):
 
-    -   :doc:`parsel <parsel:index>`: 1.5.2 → 1.5.0
+    -   ``parsel``: 1.5.2 → 1.5.0
 
-    -   :doc:`w3lib <w3lib:index>`: 1.21.0 → 1.17.0
+    -   ``w3lib``: 1.21.0 → 1.17.0
 
 -   Improved the README file (:gh:`9`)
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
     install_requires=[
         # before updating these versions, be sure they are not higher than
         # scrapy's requirements
-        "w3lib>=1.17.0",
         "parsel>=1.5.0",
         "jmespath>=0.9.5",
         "itemadapter>=0.1.0",


### PR DESCRIPTION
The code no longer imports w3lib directly (note that it's still a transitive dep via parsel).