### PR TITLE
Add minimum dependency CI job

### DIFF
--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -37,6 +37,9 @@ jobs:
         - python-version: '3.10'
           env:
             TOXENV: extra-deps
+        - python-version: '3.10'
+          env:
+            TOXENV: min-deps
         - python-version: '3.11'
           env:
             TOXENV: py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     # scrapy's requirements
     "itemadapter>=0.1.0",
     "jmespath>=0.9.5",
-    "parsel>=1.5.0",
+    "parsel>=1.8.1",
 ]
 requires-python = ">=3.10"
 classifiers = [

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,13 @@ deps =
     attrs
     scrapy
 
+[testenv:min-deps]
+deps =
+    {[testenv]deps}
+    itemadapter==0.1.0
+    jmespath==0.9.5
+    parsel==1.8.1
+
 [testenv:pypy3]
 basepython = pypy3
 


### PR DESCRIPTION
Fixes #101.

Adds a min-deps tox environment that pins the lower-bound direct dependencies, and runs it in the Ubuntu CI matrix on Python 3.10.

While adding the job, I also bumped the Parsel lower bound to 1.8.1, matching the existing JMESPath support requirement in the code and release notes.