### PR TITLE
fix: treat only None as multi-field add_value/replace_value

### DIFF
--- a/itemloaders/__init__.py
+++ b/itemloaders/__init__.py
@@ -208,7 +208,8 @@ class ItemLoader:
         value = self.get_value(value, *processors, re=re, **kw)
         if value is None:
             return self
-        if not field_name:
+        # Only None means multi-field dict; empty string is a normal field name.
+        if field_name is None:
             for k, v in value.items():
                 self._add_value(k, v)
         else:
@@ -233,7 +234,7 @@ class ItemLoader:
         value = self.get_value(value, *processors, re=re, **kw)
         if value is None:
             return self
-        if not field_name:
+        if field_name is None:
             for k, v in value.items():
                 self._replace_value(k, v)
         else:

--- a/tests/test_base_loader.py
+++ b/tests/test_base_loader.py
@@ -110,6 +110,22 @@ class TestItemLoaderBasic:
         il.add_value("name", None)
         assert il.get_collected_values("name") == []
 
+
+    def test_add_value_empty_field_name(self):
+        # Empty string is a field name; only None expands a multi-field dict.
+        il = ItemLoader()
+        il.add_value("", "plain")
+        assert il.get_collected_values("") == ["plain"]
+        il.add_value("", ["a", "b"])
+        assert il.get_collected_values("") == ["plain", "a", "b"]
+
+    def test_replace_value_empty_field_name(self):
+        il = ItemLoader()
+        il.replace_value("", "first")
+        assert il.get_collected_values("") == ["first"]
+        il.replace_value("", "second")
+        assert il.get_collected_values("") == ["second"]
+
     def test_replace_value(self):
         il = CustomItemLoader()
         il.replace_value("name", "marta")

--- a/tests/test_base_loader.py
+++ b/tests/test_base_loader.py
@@ -110,7 +110,6 @@ class TestItemLoaderBasic:
         il.add_value("name", None)
         assert il.get_collected_values("name") == []
 
-
     def test_add_value_empty_field_name(self):
         # Empty string is a field name; only None expands a multi-field dict.
         il = ItemLoader()


### PR DESCRIPTION
ItemLoader.add_value/replace_value hits AttributeError when empty field_name treated as None multi-dict path. This PR fixes the regression with a focused test covering the case.